### PR TITLE
Refine R Locus conditional to account for No Call

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -146,14 +146,13 @@ function summarizeCoatColorMods(coatColorMods) {
     }
     ul.appendChild(document.createElement("li")).textContent = item;
 
-
     item = "RALY (saddle tan) test is outdated/unreliable and should usually be ignored.";
     ul.appendChild(document.createElement("li")).textContent = item;
 
     item = processSLocus(sLocus);
     ul.appendChild(document.createElement("li")).textContent = item;
 
-    if (rLocus !== "rr") {
+    if (rLocus === "RR" || rLocus === "Rr") {
         item = "Roan detected. If there are large white areas in the coat, they should have ticking, roaning, or Dalmatian spots.";
         ul.appendChild(document.createElement("li")).textContent = item;
     }


### PR DESCRIPTION
In dogs with a No Call on the R Locus (mostly Embark for Breeders dogs who aren't tested for that), the conditional would fail because `rLocus !== 'rr'` and it would display a message that roan was detected.